### PR TITLE
Add DLib to security policy

### DIFF
--- a/policies/SECURITY.md
+++ b/policies/SECURITY.md
@@ -3,6 +3,13 @@
 | Version | Supported          |
 | ------- | ------------------ |
 | 1.0.0   | :white_check_mark: |
+
+### DLib
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.1.x | ✅ |
+| 1.0.x | ❌ |
+
 ### Other
 Only the latest commit on `main` or commit hash listed on the corresponding website is supported.
 


### PR DESCRIPTION
DLib may end up with security vulnerabilities in the future (e.g. cookie stuff) so it should be within the policy.